### PR TITLE
docs: contributor's GitHub Profile Picture integration to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 - devChallenges - [@vatsalsinghkv](https://devchallenges.io/portfolio/vatsalsinghkv)
 - Frontend Mentor - [@vatsalsinghkv](https://www.frontendmentor.io/profile/vatsalsinghkv)
 
-## Contributors
+## Current Contributors
 
 <a href="https://github.com/Prakash-Ravichandran/beautiful-animations/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=Prakash-Ravichandran/beautiful-animations" />

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@
 - devChallenges - [@vatsalsinghkv](https://devchallenges.io/portfolio/vatsalsinghkv)
 - Frontend Mentor - [@vatsalsinghkv](https://www.frontendmentor.io/profile/vatsalsinghkv)
 
+## Contributors
+
+<a href="https://github.com/Prakash-Ravichandran/beautiful-animations/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=Prakash-Ravichandran/beautiful-animations" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).
+
 ## Acknowledgements
 
 - [https://tailwindcss.com/docs/customizing-colors](https://tailwindcss.com/docs/customizing-colors) - Color Inspiration


### PR DESCRIPTION
@vatsalsinghkv ,


I have added the current contributors section to README.md file, which shows the GitHub profile pictures of all contributors - using [contrib.rocks](https://contrib.rocks/preview?repo=angular%2Fangular-ja)

Have a preview !

![image](https://github.com/vatsalsinghkv/beautiful-animations/assets/74542543/8da51f0f-c244-4a2b-8253-7100654b7f5b)
